### PR TITLE
add ignore namespace options for init apollo-client

### DIFF
--- a/agollo.go
+++ b/agollo.go
@@ -84,7 +84,7 @@ func Init(opts ...Option) (err error) {
 			err = errors.New("ApolloAddr not set")
 			return
 		}
-		initCache(gOption.ConfigCacheSize)
+		initCache(gOption.ConfigCacheSize, gOption.ignoreNameSpace)
 
 		apollo.NofityTimeout = gOption.notifyTimeout
 		apollo.ConnectTimeout = gOption.connectTimeout

--- a/option.go
+++ b/option.go
@@ -59,6 +59,8 @@ type option struct {
 	retryInterval  time.Duration
 
 	quickInitWithBK bool
+
+	ignoreNameSpace bool
 }
 
 func newDefaultOption() *option {
@@ -225,6 +227,11 @@ func WithLogFunc(logDebug, logInfo, logError logger.LogFunc) Option {
 	})
 }
 
+func IgnoreNameSpace() Option {
+	return newFuncOption(func(o *option) {
+		o.ignoreNameSpace = true
+	})
+}
 
 type funcOption struct {
 	f func(*option)

--- a/repository.go
+++ b/repository.go
@@ -20,10 +20,12 @@ const (
 var (
 	gConfigCache *freecache.Cache
 	cacheMutex   sync.Mutex
+	gIgnoreNameSpace bool
 )
 
-func initCache(sz int) *freecache.Cache {
+func initCache(sz int, ignore bool) *freecache.Cache {
 	gConfigCache = freecache.NewCache(sz)
+	gIgnoreNameSpace = ignore
 	return gConfigCache
 }
 
@@ -148,6 +150,9 @@ func getConfigChangeEvent(namespaceName string, configurations map[string]string
 }
 
 func getCacheKey(namespaceName string, key string) string {
+	if gIgnoreNameSpace {
+		return key
+	}
 	return namespaceName + SEP + key
 }
 


### PR DESCRIPTION
增加一个初始化`apollo-client`的选项，来选择是否需要屏蔽`namespace`对`key`的影响。

当不屏蔽`namespace`的时候，必须使用类似 `xxx_namespace_conf.Mysql.Addr`的key来查询，如果屏蔽就得使用`Mysql.Addr`的key来查询配置项。