### PR TITLE
fix ignoreNameSpace

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -114,6 +114,9 @@ func getConfigChangeEvent(namespaceName string, configurations map[string]string
 
 	// get old keys
 	nnd := namespaceName + SEP
+	if gIgnoreNameSpace {
+		nnd = ""
+	}
 	mp := map[string]string{}
 	it := gConfigCache.NewIterator()
 	for en := it.Next(); en != nil; en = it.Next() {


### PR DESCRIPTION
之前提交的忽略namespace选项如果启用，在产生更新项的时候会有点问题，修改来一下，如果忽略namespace，产生event的时候就使用空串作为匹配前缀。