### PR TITLE
fix ignore delete error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ log
 .vscode
 examples/go.sum
 go.sum
+.idea/

--- a/agollo_test.go
+++ b/agollo_test.go
@@ -138,7 +138,7 @@ func getTestService(notificationId int64, releaseKey string) (*service, error) {
 		return nil, errors.WithMessage(err, "loadJsonConfig")
 	}
 
-	initCache(option.ConfigCacheSize)
+	initCache(option.ConfigCacheSize, false)
 	apollo.NofityTimeout = option.notifyTimeout
 	apollo.ConnectTimeout = option.connectTimeout
 	apollo.RetryInterval = option.retryInterval

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/coocood/freecache v1.0.1
 	github.com/gin-gonic/gin v1.4.0
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/json-iterator/go v1.1.10
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/atomic v1.5.0 // indirect

--- a/repository_test.go
+++ b/repository_test.go
@@ -1,0 +1,320 @@
+package agollo
+
+import (
+	"fmt"
+	"github.com/Shonminh/apollo-client/internal/apollo"
+	"github.com/stretchr/testify/assert"
+	"sort"
+	"testing"
+)
+
+func TestCache_getChangeEvent(t *testing.T) {
+	gOption = newDefaultOption()
+	initCache(2, false)
+	nl := []*namespace{
+		{
+			NamespaceName: "immutable",
+			releaseKey:    "immutable",
+		},
+		{
+			NamespaceName: "mutable",
+			releaseKey:    "mutable",
+		},
+	}
+
+	configSets := []map[string]string{
+		{
+			"imkey1": "imvalue1",
+			"imkey2": "imvalue2",
+		},
+		{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}
+
+	/*firstExpectChanges := []*ChangeEvent{
+		{
+			Namespace: "immutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "imkey1",
+					NewValue:   "imvalue1",
+					ChangeType: 0,
+				},
+				{
+					Key:        "imkey2",
+					NewValue:   "imvalue2",
+					ChangeType: 0,
+				},
+			},
+		},
+		{
+			Namespace: "mutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "key1",
+					NewValue:   "value1",
+					ChangeType: 0,
+				},
+				{
+					Key:        "key2",
+					NewValue:   "value2",
+					ChangeType: 0,
+				},
+			},
+		},
+	}*/
+
+	configChangeSets := []map[string]string{
+		{
+			"imkey1": "im modify1",
+			"imkey3": "im add3",
+		},
+		{
+			"key1": "modify1",
+			"key3": "add3",
+		},
+	}
+	secondExpectChanges := []*ChangeEvent{
+		{
+			Namespace: "immutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "imkey3",
+					NewValue:   "im add3",
+					ChangeType: 0,
+				},
+				{
+					Key:        "imkey1",
+					OldValue:   "imvalue1",
+					NewValue:   "im modify1",
+					ChangeType: 1,
+				},
+				{
+					Key:        "imkey2",
+					OldValue:   "imvalue2",
+					ChangeType: 2,
+				},
+			},
+		},
+		{
+			Namespace: "mutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "key3",
+					NewValue:   "add3",
+					ChangeType: 0,
+				},
+				{
+					Key:        "key1",
+					OldValue:   "value1",
+					NewValue:   "modify1",
+					ChangeType: 1,
+				},
+				{
+					Key:        "key2",
+					OldValue:   "value2",
+					ChangeType: 2,
+				},
+			},
+		},
+	}
+
+	for i, ns := range nl {
+		cfg := &apollo.Config{
+			ConnConfig:     apollo.ConnConfig{NamespaceName: ns.NamespaceName},
+			Configurations: configSets[i],
+		}
+		changeEvent := getChangeEvent(cfg)
+		updateCache(cfg, ns, changeEvent)
+
+		//assert.Equal(t, firstExpectChanges[i], changeEvent)
+		fmt.Printf("nameSpace: %+v\n", changeEvent.Namespace)
+		for i := range changeEvent.Changes {
+			fmt.Printf("%+v\n", changeEvent.Changes[i])
+		}
+	}
+	b, _ := gConfigCache.Get([]byte("mutable.key1"))
+	fmt.Printf("%v\n", string(b))
+
+	for i, ns := range nl {
+		cfg := &apollo.Config{
+			ConnConfig:     apollo.ConnConfig{NamespaceName: ns.NamespaceName},
+			Configurations: configChangeSets[i],
+		}
+		cl := getChangeEvent(cfg)
+		updateCache(cfg, ns, cl)
+
+		assert.Equal(t, secondExpectChanges[i], sortChanges(cl))
+		fmt.Printf("nameSpace: %+v\n", cl.Namespace)
+		for i := range cl.Changes {
+			fmt.Printf("%+v\n", cl.Changes[i])
+		}
+	}
+}
+
+type sConfigChange []*ConfigChange
+
+func (s sConfigChange) Len() int {
+	return len(s)
+}
+
+func (s sConfigChange) Less(i, j int) bool {
+	return s[i].ChangeType < s[j].ChangeType
+}
+
+func (s sConfigChange) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func sortChanges(changes *ChangeEvent) *ChangeEvent {
+	sort.Sort(sConfigChange(changes.Changes))
+	return changes
+}
+
+func TestCache_getChangeEvent_ignore(t *testing.T) {
+	gOption = newDefaultOption()
+	initCache(2, true)
+	nl := []*namespace{
+		{
+			NamespaceName: "immutable",
+			releaseKey:    "immutable",
+		},
+		{
+			NamespaceName: "mutable",
+			releaseKey:    "mutable",
+		},
+	}
+
+	configSets := []map[string]string{
+		{
+			"imkey1": "imvalue1",
+			"imkey2": "imvalue2",
+		},
+		{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}
+
+	/*firstExpectChanges := []*ChangeEvent{
+		{
+			Namespace: "immutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "imkey1",
+					NewValue:   "imvalue1",
+					ChangeType: 0,
+				},
+				{
+					Key:        "imkey2",
+					NewValue:   "imvalue2",
+					ChangeType: 0,
+				},
+			},
+		},
+		{
+			Namespace: "mutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "key1",
+					NewValue:   "value1",
+					ChangeType: 0,
+				},
+				{
+					Key:        "key2",
+					NewValue:   "value2",
+					ChangeType: 0,
+				},
+			},
+		},
+	}*/
+
+	configChangeSets := []map[string]string{
+		{
+			"imkey1": "im modify1",
+			"imkey3": "im add3",
+		},
+		{
+			"key1": "modify1",
+			"key3": "add3",
+		},
+	}
+	secondExpectChanges := []*ChangeEvent{
+		{
+			Namespace: "immutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "imkey3",
+					NewValue:   "im add3",
+					ChangeType: 0,
+				},
+				{
+					Key:        "imkey1",
+					OldValue:   "imvalue1",
+					NewValue:   "im modify1",
+					ChangeType: 1,
+				},
+				{
+					Key:        "imkey2",
+					OldValue:   "imvalue2",
+					ChangeType: 2,
+				},
+			},
+		},
+		{
+			Namespace: "mutable",
+			Changes: []*ConfigChange{
+				{
+					Key:        "key3",
+					NewValue:   "add3",
+					ChangeType: 0,
+				},
+				{
+					Key:        "key1",
+					OldValue:   "value1",
+					NewValue:   "modify1",
+					ChangeType: 1,
+				},
+				{
+					Key:        "key2",
+					OldValue:   "value2",
+					ChangeType: 2,
+				},
+			},
+		},
+	}
+
+	for i, ns := range nl {
+		cfg := &apollo.Config{
+			ConnConfig:     apollo.ConnConfig{NamespaceName: ns.NamespaceName},
+			Configurations: configSets[i],
+		}
+		changeEvent := getChangeEvent(cfg)
+		updateCache(cfg, ns, changeEvent)
+
+		//assert.Equal(t, firstExpectChanges[i], changeEvent)
+		fmt.Printf("nameSpace: %+v\n", changeEvent.Namespace)
+		for i := range changeEvent.Changes {
+			fmt.Printf("%+v\n", changeEvent.Changes[i])
+		}
+	}
+	b, _ := gConfigCache.Get([]byte("mutable.key1"))
+	fmt.Printf("%v\n", string(b))
+
+	for i, ns := range nl {
+		cfg := &apollo.Config{
+			ConnConfig:     apollo.ConnConfig{NamespaceName: ns.NamespaceName},
+			Configurations: configChangeSets[i],
+		}
+		cl := getChangeEvent(cfg)
+		updateCache(cfg, ns, cl)
+
+		assert.Equal(t, secondExpectChanges[i], sortChanges(cl))
+		fmt.Printf("nameSpace: %+v\n", cl.Namespace)
+		for i := range cl.Changes {
+			fmt.Printf("%+v\n", cl.Changes[i])
+		}
+	}
+}


### PR DESCRIPTION
### 修复问题：

当使用 IgnoreNameSpace() 选项，开启忽略namespace的概念之后，会导致生成配置更新事件的时候，不能筛选出被删除的配置项。根本原因是namespace忽略，使得不同的namesapce的配置项会被误以为是被删除的配置。

通过修改本地缓存中的value值，使得起value可以不仅包含配置项的值还包含namesapce。