### PR TITLE
Compatible request 404

### DIFF
--- a/agollo.go
+++ b/agollo.go
@@ -116,7 +116,7 @@ func Init(opts ...Option) (err error) {
 		} else {
 			err = s.LoadConfigFile(nil)
 			if err != nil {
-				err = errors.WithMessage(err, "syncConfig init")
+				err = errors.WithMessage(err, "LoadConfigFile init")
 				return
 			}
 		}

--- a/agollo.go
+++ b/agollo.go
@@ -190,6 +190,10 @@ func (s *service) syncConfig(isInit bool, nm []*namespace) error {
 			}
 		}
 	}
+	// err only print log, dont return, cause maybe namespace success once in namespace list.
+	if retErr != nil {
+		logger.LogError(fmt.Sprintf("syncConfig failed %s", retErr.Error()))
+	}
 	return nil
 }
 

--- a/internal/apollo/config.go
+++ b/internal/apollo/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	max_retries    = 5
+	max_retries    = 0
 	ConnectTimeout = 5 * time.Second
 	RetryInterval  = 5 * time.Second
 	NofityTimeout  = 65 * time.Second

--- a/internal/apollo/config.go
+++ b/internal/apollo/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	max_retries    = 2
+	max_retries    = 5
 	ConnectTimeout = 5 * time.Second
 	RetryInterval  = 5 * time.Second
 	NofityTimeout  = 65 * time.Second

--- a/internal/apollo/config.go
+++ b/internal/apollo/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	max_retries    = 0
+	max_retries    = 2
 	ConnectTimeout = 5 * time.Second
 	RetryInterval  = 5 * time.Second
 	NofityTimeout  = 65 * time.Second

--- a/internal/apollo/request.go
+++ b/internal/apollo/request.go
@@ -95,10 +95,10 @@ func request(requestUrl string, timeout time.Duration, callBack *CallBack) (inte
 			logger.LogInfo("Gateway Timeout")
 			return nil, nil
 		case http.StatusNotFound:
-			logger.LogError("%s Not Found, resp: %+v", requestUrl, res)
+			logger.LogError("%s Not Found, resp code: %d", requestUrl, res.StatusCode)
 			return nil, nil
 		default:
-			logger.LogError("Connect Apollo Server Fail,StatusCode: %v", res.StatusCode)
+			logger.LogError("Connect Apollo Server Fail,StatusCode: %d", res.StatusCode)
 			err = errors.WithMessage(ErrInvalidHttpStatus, "status "+strconv.Itoa(res.StatusCode))
 			retErr = multierror.Append(retErr, err)
 			continue

--- a/internal/apollo/request.go
+++ b/internal/apollo/request.go
@@ -95,7 +95,7 @@ func request(requestUrl string, timeout time.Duration, callBack *CallBack) (inte
 			logger.LogInfo("Gateway Timeout")
 			return nil, nil
 		case http.StatusNotFound:
-			logger.LogError("Not Found")
+			logger.LogError("%s Not Found, resp: %+v", requestUrl, res)
 			return nil, nil
 		default:
 			logger.LogError("Connect Apollo Server Fail,StatusCode: %v", res.StatusCode)

--- a/internal/apollo/request.go
+++ b/internal/apollo/request.go
@@ -94,6 +94,9 @@ func request(requestUrl string, timeout time.Duration, callBack *CallBack) (inte
 		case http.StatusGatewayTimeout:
 			logger.LogInfo("Gateway Timeout")
 			return nil, nil
+		case http.StatusNotFound:
+			logger.LogError("Not Found")
+			return nil, nil
 		default:
 			logger.LogError("Connect Apollo Server Fail,StatusCode: %v", res.StatusCode)
 			err = errors.WithMessage(ErrInvalidHttpStatus, "status "+strconv.Itoa(res.StatusCode))


### PR DESCRIPTION
当某个namespace没有发布，apollo服务端会返回404，跳过这种情况，不返回错误，只打印error。